### PR TITLE
Use flex-grid for Topics. So it's a shorter list and responsive

### DIFF
--- a/app-wiki/tiddlers/app/templates/Styles.tid
+++ b/app-wiki/tiddlers/app/templates/Styles.tid
@@ -340,6 +340,9 @@ Details
 .tc-list-vertical {
     list-style: none;
     padding: 0;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-around;
 }
 
 .tc-list-vertical > li {


### PR DESCRIPTION
Use flex-grid for Topics. So it's a shorter list and responsive

![grafik](https://user-images.githubusercontent.com/374655/113210867-06551400-9275-11eb-91e8-dcb8a1bc2396.png)
