### PR TITLE
Add simon's links site to sites.json

### DIFF
--- a/sites/sites.json
+++ b/sites/sites.json
@@ -38,5 +38,9 @@
 	{
 		"name": "bimlas",
 		"url": "https://bimlas.gitlab.io/tw5-link-collection/index.html"
+	},
+	{
+		"name": "simon",
+		"url": "https://simon-links.tiddlyhost.com/"
 	}
 ]


### PR DESCRIPTION
Currently all my links are related to Tiddlyhost and Tiddlyspot.

See https://simon-links.tiddlyhost.com/